### PR TITLE
Make it possible to build pazuzu binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ for building and testing. Pazuzu can significantly ease that process, by letting
 choose from a wide selection of predefined Dockerfile snippets that represent 
 those dependencies (e.g. Golang, Python, Android SDK, customized NPM installs). 
 
+## How to build pazuzu executable
+
+```
+lein bin
+```
+
+This will produce the executable `target/pazuzu`.
+
 License
 -------
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,2 +1,0 @@
-# pazuzu-cli
-Pazuzu, the Docker Maker

--- a/cli/project.clj
+++ b/cli/project.clj
@@ -7,11 +7,9 @@
                  [pazuzu-core "0.1.0"]
                  [org.clojure/data.json "0.2.6"]]
   :main ^:skip-aot pazuzu-cli.core
-  :target-path "target/%s"
   :profiles {:uberjar {:aot :all}
-             :dev {:plugins      [[lein-midje "3.2"]]
+             :dev {:plugins      [[lein-midje "3.2"]
+                                  [lein-bin "0.3.4"]]
                    :dependencies [[midje "1.8.3"]
-                                  [org.clojure/tools.namespace "0.2.11"]]}})
-
-
-
+                                  [org.clojure/tools.namespace "0.2.11"]]}}
+  :bin { :name "pazuzu" })

--- a/core/README.md
+++ b/core/README.md
@@ -1,2 +1,0 @@
-# pazuzu-core
-Pazuzu, the Docker Maker


### PR DESCRIPTION
This makes it possible to build a pazuzu 'binary' using [lein-bin] so you can type `pazuzu build -f ...` instead of `java -jar path/to/jar build -f ...`.

Note this is based on #18 so I will rebase once that is merged.

[lein-bin]: https://github.com/Raynes/lein-bin
